### PR TITLE
feat(installation): Use MariaDB with healthcheck in docker-compose example

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -96,7 +96,6 @@ For more information, please visit [Configuration](/configuration).
 A full production deployment example (using `mysql` as database):
 
 ```
-version: "2"
 services:
   ezbookkeeping:
     image: mayswind/ezbookkeeping

--- a/installation.md
+++ b/installation.md
@@ -93,7 +93,7 @@ For more information, please visit [Configuration](/configuration).
 
 ### Use docker-compose
 
-A full production deployment example (using `mysql` as database):
+A full production deployment example (using `mariadb` as database and ensuring ezBookkeeping starts after the database is ready):
 
 ```
 services:
@@ -107,7 +107,7 @@ services:
       - "EBK_SERVER_DOMAIN=ezbookkeeping.yourdomain"
       - "EBK_SERVER_ENABLE_GZIP=true"
       - "EBK_DATABASE_TYPE=mysql"
-      - "EBK_DATABASE_HOST=mysql:3306"
+      - "EBK_DATABASE_HOST=db:3306"
       - "EBK_DATABASE_NAME=ezbookkeeping"
       - "EBK_DATABASE_USER=ezbookkeeping"
       - "EBK_DATABASE_PASSWD=ezbookkeeping"
@@ -117,6 +117,27 @@ services:
       - "/etc/localtime:/etc/localtime:ro"
       - "/var/lib/ezbookkeeping/storage:/ezbookkeeping/storage" # make sure the UID:GID is 1000:1000
       - "/var/log/ezbookkeeping:/ezbookkeeping/log" # make sure the UID:GID is 1000:1000
+    depends_on:
+      db:
+        condition: service_healthy
+  db:
+    image: mariadb:latest
+    container_name: ezbookkeeping_db
+    hostname: "db"
+    environment:
+      - "MARIADB_ROOT_PASSWORD=replace_with_mariadb_root_password"
+      - "MARIADB_DATABASE=ezbookkeeping"
+      - "MARIADB_USER=ezbookkeeping"
+      - "MARIADB_PASSWORD=ezbookkeeping"
+    volumes:
+      - "/var/lib/ezbookkeeping/mariadb:/var/lib/mysql"
+      - "/etc/localtime:/etc/localtime:ro"
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 10s
+      interval: 10s
+      timeout: 5s
+      retries: 3
 ```
 
 ## Install from binary

--- a/zh_Hans/installation.md
+++ b/zh_Hans/installation.md
@@ -94,7 +94,7 @@ permalink: /zh_Hans/installation
 
 ### 使用 docker-compose
 
-一个完整的生产部署示例（使用 `mysql` 作为数据库）：
+一个完整的生产部署示例（使用 `mariadb` 作为数据库，并确保 ezBookkeeping 在数据库就绪后启动）：
 
 ```
 services:
@@ -108,7 +108,7 @@ services:
       - "EBK_SERVER_DOMAIN=ezbookkeeping.yourdomain"
       - "EBK_SERVER_ENABLE_GZIP=true"
       - "EBK_DATABASE_TYPE=mysql"
-      - "EBK_DATABASE_HOST=mysql:3306"
+      - "EBK_DATABASE_HOST=db:3306"
       - "EBK_DATABASE_NAME=ezbookkeeping"
       - "EBK_DATABASE_USER=ezbookkeeping"
       - "EBK_DATABASE_PASSWD=ezbookkeeping"
@@ -118,6 +118,27 @@ services:
       - "/etc/localtime:/etc/localtime:ro"
       - "/var/lib/ezbookkeeping/storage:/ezbookkeeping/storage" # 请确保 UID:GID 是 1000:1000
       - "/var/log/ezbookkeeping:/ezbookkeeping/log" # 请确保 UID:GID 是 1000:1000
+    depends_on:
+      db:
+        condition: service_healthy
+  db:
+    image: mariadb:latest
+    container_name: ezbookkeeping_db
+    hostname: "db"
+    environment:
+      - "MARIADB_ROOT_PASSWORD=replace_with_mariadb_root_password"
+      - "MARIADB_DATABASE=ezbookkeeping"
+      - "MARIADB_USER=ezbookkeeping"
+      - "MARIADB_PASSWORD=ezbookkeeping"
+    volumes:
+      - "/var/lib/ezbookkeeping/mariadb:/var/lib/mysql"
+      - "/etc/localtime:/etc/localtime:ro"
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 10s
+      interval: 10s
+      timeout: 5s
+      retries: 3
 ```
 
 ## 从二进制包安装

--- a/zh_Hans/installation.md
+++ b/zh_Hans/installation.md
@@ -97,7 +97,6 @@ permalink: /zh_Hans/installation
 一个完整的生产部署示例（使用 `mysql` 作为数据库）：
 
 ```
-version: "2"
 services:
   ezbookkeeping:
     image: mayswind/ezbookkeeping


### PR DESCRIPTION
This PR updates the docker-compose example provided in the installation documentation (`installation.md` and `zh_Hans/installation.md`) to use MariaDB instead of MySQL.

Key changes include:

*   Replaced the `mysql` service definition with a `mariadb` service using the official `mariadb:latest` image.
*   Introduced a `healthcheck` for the MariaDB service utilizing the official `healthcheck.sh` script provided by the image. This ensures the database service is properly initialized and ready for connections before other services depend on it.
*   Added `depends_on: condition: service_healthy` to the `ezbookkeeping` service definition. This makes the `ezbookkeeping` container wait until the `db` (MariaDB) container reports a healthy status, addressing potential startup issues where the application might try to connect to the database before it's fully available.
*   Updated relevant environment variables (e.g., `EBK_DATABASE_HOST`) to point to the new database service name (`db`).

The example continues to use host path volumes for data persistence, maintaining consistency with the previous structure. This change enhances the reliability of the docker-compose setup example.