### PR TITLE
Add Kubernetes Deployment Documentation

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -154,16 +154,16 @@ After installation, go to the "Installed Apps" page and click "Open" to access t
 
 ## Kubernetes Deployment
 
-For production deployments in Kubernetes, ezBookkeeping can be deployed using the following manifests. This example demonstrates a complete setup with PostgreSQL as the database backend, persistent storage for user uploads and logs, and an Ingress configuration with TLS support.
+For production deployments in Kubernetes, ezBookkeeping can be deployed using the following manifests. This example demonstrates a complete setup with persistent storage for SQLite database, user uploads and logs, and an Ingress configuration with TLS support.
 
 Before applying these manifests, make sure to:
-- Create or choose a namespace and replace `my-namespace` in the apply commands below
+- Create a namespace `ezbookkeeping`
 - Replace `my-server-hostname` with your actual node hostname if using node affinity
 - Generate secure values for secrets in `secret.yaml` (use `echo -n "secret-value" | base64`)
 - Update `ezbookkeeping.yourdomain` with your actual domain name
-- Ensure you have NGINX Ingress Controller installed in your cluster
-- Ensure you have cert-manager installed with a configured ClusterIssuer named `letsencrypt-cluster` for automatic TLS certificate provisioning
-- The manifests use `local-storage` StorageClass. Either create this StorageClass or update `storageClassName` in all manifests to use your cluster's storage solution (e.g., `longhorn`, `nfs-client`, `ceph-rbd`, or your cloud provider's default storage class)
+- Ensure you have Nginx Ingress Controller installed in your cluster
+- Ensure you have cert-manager installed with a configured ClusterIssuer (`letsencrypt-cluster` in this example) for automatic TLS certificate provisioning
+- Replace `my-storage-class` with the StorageClass name you use in your cluster (e.g., `longhorn`, `nfs-client`, `ceph-rbd`, `local-storage`, or your cloud provider's default storage class)
 
 ### secret.yaml
 
@@ -192,7 +192,7 @@ metadata:
   labels:
     app: "ezbookkeeping"
 spec:
-  storageClassName: local-storage
+  storageClassName: my-storage-class
   selector:
     matchLabels:
       pv-for: "ezbookkeeping-storage"
@@ -210,7 +210,7 @@ metadata:
   labels:
     app: "ezbookkeeping"
 spec:
-  storageClassName: local-storage
+  storageClassName: my-storage-class
   selector:
     matchLabels:
       pv-for: "ezbookkeeping-logs"
@@ -338,9 +338,9 @@ spec:
 ### Apply manifests
 
 ```bash
-kubectl apply -f secret.yaml -n "my-namespace"
-kubectl apply -f ezbookkeeping.yaml -n "my-namespace"
-kubectl apply -f ingress.yaml -n "my-namespace"
+kubectl apply -f secret.yaml -n "ezbookkeeping"
+kubectl apply -f ezbookkeeping.yaml -n "ezbookkeeping"
+kubectl apply -f ingress.yaml -n "ezbookkeeping"
 ```
 
 

--- a/installation.md
+++ b/installation.md
@@ -245,7 +245,8 @@ spec:
         runAsGroup: 1000
         fsGroup: 1000
       containers:
-      - image: "mayswind/ezbookkeeping:1.2.0" # perform updates manually by changing the image tag
+      - image: "mayswind/ezbookkeeping:latest" # you can set specific version here (:1.2.0) for manual update control
+        imagePullPolicy: Always  # Required for :latest tag to ensure fresh image pulls. Use IfNotPresent for specific versions
         name: "ezbookkeeping"
         env:
         - name: EBK_SECURITY_SECRET_KEY
@@ -254,15 +255,13 @@ spec:
               name: "ezbookkeeping-secret"
               key: EBK_SECURITY_SECRET_KEY
         - name: EBK_SERVER_PROTOCOL
-          value: "http"
+          value: "http"  # Ingress will handle HTTPS termination
         - name: EBK_SERVER_DOMAIN
           value: "ezbookkeeping.yourdomain"
         - name: EBK_SERVER_ENABLE_GZIP
           value: "true"
         - name: EBK_LOG_MODE
-          value: "file"
-        - name: EBK_USER_ENABLE_REGISTER
-          value: "true"  # or "false" to disable user registration after first admin user created
+          value: "console"  # Logs are collected from stdout/stderr in Kubernetes and can be accessed via `kubectl logs`
         ports:
         - containerPort: 8080
           name: ezbookkeeping
@@ -275,14 +274,14 @@ spec:
             cpu: "2"
         volumeMounts:
         - mountPath: "/ezbookkeeping/storage"
-          name: "ebk-storage"
+          name: "ezbookkeeping-storage"
         - mountPath: "/ezbookkeeping/log"
-          name: "ebk-logs"
+          name: "ezbookkeeping-logs"
       volumes:
-        - name: "ebk-storage"
+        - name: "ezbookkeeping-storage"
           persistentVolumeClaim:
             claimName: "ezbookkeeping-storage-pvc"
-        - name: "ebk-logs"
+        - name: "ezbookkeeping-logs"
           persistentVolumeClaim:
             claimName: "ezbookkeeping-logs-pvc"
 

--- a/installation.md
+++ b/installation.md
@@ -160,7 +160,6 @@ For production deployments in Kubernetes, ezBookkeeping can be deployed referrin
 
 Before applying these manifests, make sure to:
 - Create a namespace `ezbookkeeping`
-- Replace `my-server-hostname` with your actual node hostname if using node affinity
 - Generate secure values for secrets in `secret.yaml` (use `echo -n "secret-value" | base64`)
 - Update `ezbookkeeping.yourdomain` with your actual domain name
 - Ensure you have Nginx Ingress Controller installed in your cluster
@@ -241,8 +240,6 @@ spec:
       labels:
         app: "ezbookkeeping"
     spec:
-      nodeSelector:
-        kubernetes.io/hostname: "my-server-hostname"
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000

--- a/installation.md
+++ b/installation.md
@@ -434,6 +434,13 @@ spec:
         ports:
         - containerPort: 8080
           name: ezbookkeeping
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "1Gi"
+            cpu: "2"
         volumeMounts:
         - mountPath: "/ezbookkeeping/storage"
           name: "ebk-storage"

--- a/installation.md
+++ b/installation.md
@@ -154,7 +154,9 @@ After installation, go to the "Installed Apps" page and click "Open" to access t
 
 ## Kubernetes Deployment
 
-For production deployments in Kubernetes, ezBookkeeping can be deployed using the following manifests. This example demonstrates a complete setup with persistent storage for SQLite database and user uploads, and an Ingress configuration with TLS support.
+For production deployments in Kubernetes, ezBookkeeping can be deployed referring to the following manifests. This example demonstrates a production-ready setup with:
+- ezBookkeeping deployment with persistent storages for SQLite database and user uploads
+- Ingress configuration with TLS/HTTPS support
 
 Before applying these manifests, make sure to:
 - Create a namespace `ezbookkeeping`


### PR DESCRIPTION
## Summary
Added comprehensive Kubernetes deployment guide with production-ready manifests for deploying ezBookkeeping with PostgreSQL backend, persistent storage, and TLS-enabled Ingress.

## What's Included

- secret.yaml - Secrets for database password and app secret key
- pg.yaml - PostgreSQL StatefulSet with persistent storage (10Gi)
- ebk.yaml - ezBookkeeping Deployment with persistent volumes for uploads (9Gi) and logs (9Gi)
- ingress.yaml - NGINX Ingress with cert-manager for automatic TLS certificates

Documentation includes checklist for:

- Namespace setup
- NGINX Ingress Controller requirement
- cert-manager with ClusterIssuer configuration
- StorageClass options (local-storage, longhorn, nfs-client, ceph-rbd, etc.)

All manifests are ready to deploy with simple kubectl apply commands.